### PR TITLE
latest pre-commit does not support py3.8 anymore

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
 
     # Required for the PR comment action
     # permissions:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated CI configuration to support Python versions 3.9 to 3.12, removing support for Python 3.8.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->