### PR TITLE
Add final job to fix matrix status check being separate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,3 +53,19 @@ jobs:
     #   with:
     #     filePath: pytest.log
     #   if: github.event_name == 'pull_request'
+
+  # This job is to ensure that there's a status check to protect branches with
+  results:
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    name: Final Results
+    needs: [test]
+    steps:
+      - run: exit 1
+        # see https://stackoverflow.com/a/67532120/4907315
+        if: >-
+          ${{
+               contains(needs.*.result, 'failure')
+            || contains(needs.*.result, 'cancelled')
+            || contains(needs.*.result, 'skipped')
+          }}


### PR DESCRIPTION
### **PR Type**
enhancement, configuration changes


___

### **Description**
- Added a new job named `Final Results` in the GitHub Actions workflow to ensure a status check for branch protection.
- Configured the `Final Results` job to run always and depend on the `test` job.
- Included conditional logic to fail the `Final Results` job if any dependent job fails, is cancelled, or is skipped.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ci.yml</strong><dd><code>Add final job to ensure status check for branch protection</code></dd></summary>
<hr>
      
.github/workflows/ci.yml

<li>Added a new job named <code>Final Results</code> to ensure a status check for <br>branch protection.<br> <li> Configured the job to run always and depend on the <code>test</code> job.<br> <li> Included conditional logic to fail the job if any dependent job fails, <br>is cancelled, or is skipped.<br>


</details>
    

  </td>
  <td><a href="https://github.com/madeddie/tyora/pull/52/files#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03f">+16/-0</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

