### PR TITLE
Add global http timeout to the session

### DIFF
--- a/tyora/session.py
+++ b/tyora/session.py
@@ -10,7 +10,7 @@ from requests_toolbelt import user_agent
 
 from .utils import find_link, parse_form
 
-HTTP_TIMEOUT = 10
+HTTP_TIMEOUT = int(os.getenv("HTTP_TIMEOUT", 10))
 logger = logging.getLogger(__name__)
 
 try:

--- a/tyora/session.py
+++ b/tyora/session.py
@@ -10,6 +10,7 @@ from requests_toolbelt import user_agent
 
 from .utils import find_link, parse_form
 
+HTTP_TIMEOUT = 10
 logger = logging.getLogger(__name__)
 
 try:
@@ -32,6 +33,10 @@ class MoocfiCsesSession(requests.Session):
         self.headers.update(
             {"User-Agent": user_agent(os.path.basename(sys.argv[0]), __version__)}
         )
+
+    def request(self, *args, **kwargs):
+        kwargs.setdefault("timeout", HTTP_TIMEOUT)
+        return super(MoocfiCsesSession, self).request(*args, **kwargs)
 
     @property
     def is_logged_in(self) -> bool:


### PR DESCRIPTION
### **User description**
requests doesn't use a default timeout, this will make sure all requests have a maximum timeout configured.


___

### **PR Type**
enhancement


___

### **Description**
- Introduced a global HTTP timeout constant (`HTTP_TIMEOUT`) set to 10 seconds in `tyora/session.py`.
- Updated the `request` method in the `MoocfiCsesSession` class to use the default timeout, ensuring all HTTP requests have a maximum timeout configured.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>session.py</strong><dd><code>Add global HTTP timeout to session requests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
tyora/session.py

<li>Added a global HTTP timeout constant (<code>HTTP_TIMEOUT</code>) set to 10 seconds.<br> <li> Modified the <code>request</code> method to include the default timeout.<br>


</details>
    

  </td>
  <td><a href="https://github.com/madeddie/tyora/pull/61/files#diff-4f1d1b96a5d6416223956e6910e54895a5a8ab4db9ae262cbbc37075704639c7">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a default timeout for HTTP requests to improve reliability.

- **Improvements**
  - Enhanced session management with an updated `is_logged_in` property for better user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->